### PR TITLE
Formatting directive to display goroutine ID

### DIFF
--- a/rlog.go
+++ b/rlog.go
@@ -17,6 +17,7 @@ package rlog
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"log"
@@ -45,6 +46,10 @@ const (
 	levelInfo
 	levelDebug
 	levelTrace
+)
+
+const (
+	GIDFormatString = "%G"
 )
 
 // Translation map from level to string representation
@@ -611,7 +616,7 @@ func basicLog(logLevel int, traceLevel int, isLocked bool, format string, prefix
 	// Assemble the actual log line
 	var msg string
 	if format != "" {
-		msg = fmt.Sprintf(format, a...)
+		msg = fmtWithGID(format, a...)
 	} else {
 		msg = fmt.Sprintln(a...)
 	}
@@ -624,6 +629,28 @@ func basicLog(logLevel int, traceLevel int, isLocked bool, format string, prefix
 	if logWriterFile != nil {
 		logWriterFile.Printf(logLine)
 	}
+}
+
+// fmtWithGID is like fmt.Sprintf, but adds another format character,
+// %G, which will be subsituted with Goroutine ID.
+func fmtWithGID(s string, args ...interface{}) string {
+	if strings.ContainsAny(s, GIDFormatString) {
+		gid := fmt.Sprintf("%d", getGID())
+		s = strings.Replace(s, GIDFormatString, gid, -1)
+	}
+	return fmt.Sprintf(s, args...)
+}
+
+// getGID gets the current goroutine ID (algorithm from
+// https://blog.sgmansfield.com/2015/12/goroutine-ids/) by
+// unwinding the stack.
+func getGID() uint64 {
+	b := make([]byte, 64)
+	b = b[:runtime.Stack(b, false)]
+	b = bytes.TrimPrefix(b, []byte("goroutine "))
+	b = b[:bytes.IndexByte(b, ' ')]
+	n, _ := strconv.ParseUint(string(b), 10, 64)
+	return n
 }
 
 // Trace is for low level tracing of activities. It takes an additional 'level'

--- a/rlog_test.go
+++ b/rlog_test.go
@@ -179,6 +179,36 @@ func TestLogLevelsLimited(t *testing.T) {
 	fileMatch(t, checkLines, "")
 }
 
+// TestLogFormattedGID checks whether the *f functions for formatted output work
+// as expected with a %G format
+func TestLogFormattedGID(t *testing.T) {
+	conf := setup()
+	defer cleanup()
+
+	conf.logLevel = "DEBUG"
+	conf.traceLevel = "1"
+	initialize(conf, true)
+
+	gid := getGID()
+
+	Debugf("%G: Test Debug %d", 123)
+	Infof("%G: Test Info %d", 123)
+	Warnf("%G: Test Warning %d", 123)
+	Errorf("%G: Test Error %d", 123)
+	Criticalf("%G: Test Critical %d", 123)
+	Tracef(1, "%G: Trace 1 %d", 123)
+	Tracef(2, "%G: Trace 2 %d", 123)
+	checkLines := []string{
+		fmt.Sprintf("DEBUG    : %d: Test Debug 123", gid),
+		fmt.Sprintf("INFO     : %d: Test Info 123", gid),
+		fmt.Sprintf("WARN     : %d: Test Warning 123", gid),
+		fmt.Sprintf("ERROR    : %d: Test Error 123", gid),
+		fmt.Sprintf("CRITICAL : %d: Test Critical 123", gid),
+		fmt.Sprintf("TRACE(1) : %d: Trace 1 123", gid),
+	}
+	fileMatch(t, checkLines, "")
+}
+
 // TestLogFormatted checks whether the *f functions for formatted output work
 // as expected.
 func TestLogFormatted(t *testing.T) {
@@ -278,7 +308,7 @@ func TestLogCallerInfo(t *testing.T) {
 		dirPath, moduleName = path.Split(dirPath)
 	}
 	moduleAndFileName := moduleName + "/" + fileName
-	shouldLine := fmt.Sprintf("INFO     : [%s:%d (%s)] Test Info",
+	shouldLine := fmt.Sprintf("INFO     : [%d %s:%d (%s)] Test Info", os.Getpid(),
 		moduleAndFileName, line, callingFuncName)
 
 	checkLines := []string{shouldLine}


### PR DESCRIPTION
Added formatting directive %G to display goroutine ID, also fixed a test for caller info -- was failing due to missing PID that was added later, I assume