### PR TITLE
logline should be printed using Print, not Printf, because when a log…

### DIFF
--- a/rlog.go
+++ b/rlog.go
@@ -619,10 +619,10 @@ func basicLog(logLevel int, traceLevel int, isLocked bool, format string, prefix
 	logLine := fmt.Sprintf("%s%-9s: %s%s",
 		now.Format(settingDateTimeFormat), levelDecoration, callerInfo, msg)
 	if logWriterStream != nil {
-		logWriterStream.Printf(logLine)
+		logWriterStream.Print(logLine)
 	}
 	if logWriterFile != nil {
-		logWriterFile.Printf(logLine)
+		logWriterFile.Print(logLine)
 	}
 }
 


### PR DESCRIPTION
…line contains a percent sign, it is interpreted as a format specifier.

Example:
rlog.Println("10% discount")

Results in:
2017-11-03T14:02:59+01:00 INFO     : 10%!d(MISSING)iscount

After this fix, the result is:
2017-11-03T14:03:58+01:00 INFO     : 10% discount

