### PR TITLE
Add support for go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/romana/rlog
+
+go 1.16


### PR DESCRIPTION
Add support for go modules with go 1.16 as the least go version supported by the project. It fixes #25 